### PR TITLE
Stride scheduler

### DIFF
--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -189,3 +189,6 @@ uint32          rand_range(uint32 min, uint32 max);
 
 // number of elements in fixed-size array
 #define NELEM(x) (sizeof(x)/sizeof((x)[0]))
+
+// Q32.32의 1.0을 L(max_tickets)로 사용
+#define STRIDE_SCALE (1ULL<<32)

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -445,52 +445,46 @@ scheduler(void)
     struct proc *min_pass_proc = 0;
 
     for(p = proc; p < &proc[NPROC]; p++) {
-      struct proc *prev_min_pass_proc = min_pass_proc;
-
       acquire(&p->lock);
-      if(p->state == RUNNABLE) {
-        if (min_pass_proc == 0) {
-          min_pass_proc = p;
-        } else {
-          acquire(&prev_min_pass_proc->lock);
-          if (p->pass < min_pass_proc->pass) {
-            min_pass_proc = p;
-          } else if (p->pass == min_pass_proc->pass && p->pid < min_pass_proc->pid) {
-            min_pass_proc = p;
-          }
-          release(&prev_min_pass_proc->lock);
-        }
+      if (p->state != RUNNABLE) {
+        release(&p->lock);
+        continue;
       }
-      release(&p->lock);
-    }
 
-    _Bool found = 0;
-    if (min_pass_proc != 0) {
-        acquire(&min_pass_proc->lock);
-
-        // 프로세스가 상태가 변경되지 않았는지 검사
-        if(min_pass_proc->state == RUNNABLE) {
-          min_pass = min_pass_proc->pass;
-
-          // Switch to chosen process.  It is the process's job
-          // to release its lock and then reacquire it
-          // before jumping back to us.
-          min_pass_proc->state = RUNNING;
-          min_pass_proc->ticks++;
-          min_pass_proc->pass += STRIDE_SCALE / (uint64)min_pass_proc->tickets;
-          c->proc = min_pass_proc;
-          swtch(&c->context, &min_pass_proc->context);
-
-          // Process is done running for now.
-          // It should have changed its p->state before coming back.
-          c->proc = 0;
-          found = 1;
-        }
+      if (min_pass_proc == 0) {
+        min_pass_proc = p;
+      } else if (
+          (p->pass < min_pass_proc->pass) ||
+          (p->pass == min_pass_proc->pass && p->pid < min_pass_proc->pid)
+      ) {
         release(&min_pass_proc->lock);
+        min_pass_proc = p;
+      } else {
+        release(&p->lock);
+      }
     }
 
-    // RUNNABLE인 프로세스가 없거나, 실행대상 프로세스가 이미 실행된 경우
-    if (found == 0) {
+    if (min_pass_proc != 0) {
+        // min_pass_proc은 찾는 과정에서 이미 lock이 걸려있기 때문에
+        // 상태가 유지된다.
+
+        min_pass = min_pass_proc->pass;
+
+        // Switch to chosen process.  It is the process's job
+        // to release its lock and then reacquire it
+        // before jumping back to us.
+        min_pass_proc->state = RUNNING;
+        min_pass_proc->ticks++;
+        min_pass_proc->pass += STRIDE_SCALE / (uint64)min_pass_proc->tickets;
+        c->proc = min_pass_proc;
+        swtch(&c->context, &min_pass_proc->context);
+
+        // Process is done running for now.
+        // It should have changed its p->state before coming back.
+        c->proc = 0;
+
+        release(&min_pass_proc->lock);
+    } else {
       // nothing to run; stop running on this core until an interrupt.
       asm volatile("wfi");
     }

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -476,6 +476,7 @@ scheduler(void)
           // before jumping back to us.
           p->state = RUNNING;
           p->ticks++;
+          p->pass += STRIDE_SCALE / (uint64)p->tickets;
           c->proc = p;
           swtch(&c->context, &p->context);
 

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -27,7 +27,7 @@ extern char trampoline[]; // trampoline.S
 // must be acquired before any p->lock.
 struct spinlock wait_lock;
 
-static uint64 min_pass = 0;
+static _Atomic uint64 min_pass = 0;
 
 // Allocate a page for each process's kernel stack.
 // Map it high in memory, followed by an invalid

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -27,6 +27,8 @@ extern char trampoline[]; // trampoline.S
 // must be acquired before any p->lock.
 struct spinlock wait_lock;
 
+static uint64 min_pass = 0;
+
 // Allocate a page for each process's kernel stack.
 // Map it high in memory, followed by an invalid
 // guard page.
@@ -127,7 +129,7 @@ found:
   p->state = USED;
   p->tickets = 1;
   p->ticks = 0;
-  p->pass = 0;
+  p->pass = min_pass;
 
   // Allocate a trapframe page.
   if((p->trapframe = (struct trapframe *)kalloc()) == 0){
@@ -470,6 +472,8 @@ scheduler(void)
 
         // 프로세스가 상태가 변경되지 않았는지 검사
         if(min_pass_proc->state == RUNNABLE) {
+          min_pass = min_pass_proc->pass;
+
           // Switch to chosen process.  It is the process's job
           // to release its lock and then reacquire it
           // before jumping back to us.

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -127,6 +127,7 @@ found:
   p->state = USED;
   p->tickets = 1;
   p->ticks = 0;
+  p->pass = 0;
 
   // Allocate a trapframe page.
   if((p->trapframe = (struct trapframe *)kalloc()) == 0){
@@ -174,6 +175,7 @@ freeproc(struct proc *p)
   p->state = UNUSED;
   p->tickets = 0;
   p->ticks = 0;
+  p->pass = 0;
 }
 
 // Create a user page table for a given process, with no user memory,

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -440,57 +440,54 @@ scheduler(void)
     intr_on();
     intr_off();
 
-    struct proc *runnable_procs[NPROC];
-    uint32 tickets[NPROC];
-    uint32 total_tickets = 0;
-    int runnable_count = 0;
+    struct proc *min_pass_proc = 0;
 
     for(p = proc; p < &proc[NPROC]; p++) {
+      struct proc *prev_min_pass_proc = min_pass_proc;
+
+      if (prev_min_pass_proc != 0) {
+        acquire(&prev_min_pass_proc->lock);
+      }
       acquire(&p->lock);
       if(p->state == RUNNABLE) {
-        runnable_procs[runnable_count] = p;
-        tickets[runnable_count] = p->tickets;
-        total_tickets += p->tickets;
-        runnable_count++;
+        if (min_pass_proc == 0) {
+          min_pass_proc = p;
+        } else if (p->pass < min_pass_proc->pass) {
+          min_pass_proc = p;
+        } else if (p->pass == min_pass_proc->pass && p->pid < min_pass_proc->pid) {
+          min_pass_proc = p;
+        }
       }
       release(&p->lock);
+      if (prev_min_pass_proc != 0) {
+        release(&prev_min_pass_proc->lock);
+      }
     }
-    
-    // 프로세스 A, B, C가 가진 티켓의 수량이 30개, 20개 10개 이면
-    // A: 1~30, B: 31~50, C: 51~60 으로 보정하여 추첨 할 수 있도록
-    // 현재까지 추첨되지 않은 프로세스의 티켓들을 누적
-    uint32 winning_number = rand_range(1, total_tickets);
-    uint32 cumulative_tickets = 0;
-    _Bool found = 0;
 
-    for(int i = 0; i < runnable_count; i++) {
-      cumulative_tickets += tickets[i];
-      if (winning_number <= cumulative_tickets) {
-        p = runnable_procs[i];
-        acquire(&p->lock);
+    _Bool found = 0;
+    if (min_pass_proc != 0) {
+        acquire(&min_pass_proc->lock);
 
         // 프로세스가 상태가 변경되지 않았는지 검사
-        if(p->state == RUNNABLE) {
+        if(min_pass_proc->state == RUNNABLE) {
           // Switch to chosen process.  It is the process's job
           // to release its lock and then reacquire it
           // before jumping back to us.
-          p->state = RUNNING;
-          p->ticks++;
-          p->pass += STRIDE_SCALE / (uint64)p->tickets;
-          c->proc = p;
-          swtch(&c->context, &p->context);
+          min_pass_proc->state = RUNNING;
+          min_pass_proc->ticks++;
+          min_pass_proc->pass += STRIDE_SCALE / (uint64)min_pass_proc->tickets;
+          c->proc = min_pass_proc;
+          swtch(&c->context, &min_pass_proc->context);
 
           // Process is done running for now.
           // It should have changed its p->state before coming back.
           c->proc = 0;
           found = 1;
         }
-        release(&p->lock);
-        break;
-      }
+        release(&min_pass_proc->lock);
     }
 
-    // RUNNABLE인 프로세스가 없거나, 추첨된 프로세스가 이미 실행된 경우
+    // RUNNABLE인 프로세스가 없거나, 실행대상 프로세스가 이미 실행된 경우
     if (found == 0) {
       // nothing to run; stop running on this core until an interrupt.
       asm volatile("wfi");

--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -447,23 +447,21 @@ scheduler(void)
     for(p = proc; p < &proc[NPROC]; p++) {
       struct proc *prev_min_pass_proc = min_pass_proc;
 
-      if (prev_min_pass_proc != 0) {
-        acquire(&prev_min_pass_proc->lock);
-      }
       acquire(&p->lock);
       if(p->state == RUNNABLE) {
         if (min_pass_proc == 0) {
           min_pass_proc = p;
-        } else if (p->pass < min_pass_proc->pass) {
-          min_pass_proc = p;
-        } else if (p->pass == min_pass_proc->pass && p->pid < min_pass_proc->pid) {
-          min_pass_proc = p;
+        } else {
+          acquire(&prev_min_pass_proc->lock);
+          if (p->pass < min_pass_proc->pass) {
+            min_pass_proc = p;
+          } else if (p->pass == min_pass_proc->pass && p->pid < min_pass_proc->pid) {
+            min_pass_proc = p;
+          }
+          release(&prev_min_pass_proc->lock);
         }
       }
       release(&p->lock);
-      if (prev_min_pass_proc != 0) {
-        release(&prev_min_pass_proc->lock);
-      }
     }
 
     _Bool found = 0;

--- a/kernel/proc.h
+++ b/kernel/proc.h
@@ -107,4 +107,5 @@ struct proc {
   char name[16];               // Process name (debugging)
   uint32 tickets;
   uint32 ticks;
+  uint64 pass;
 };


### PR DESCRIPTION
## stride 동작방식

- 모든 프로세스는 각자의 '보폭(stride)'을 가진다.
- 스케쥴러가 프로세스를 실행시키면 해당 프로세스는 'stride'만큼의 '거리(pass)'를 이동한다.
- 스케쥴러는 항상 가장 '짧은 거리를 이동한(pass가 가장 작은)' 프로세스를 실행시킨다.
- 결과적으로 보폭이 작을수록 더 자주 실행된다.

## 고려사항

- stride로 바뀌면 lottery와는 달리 더 자주 실행되어야 할 프로세스에 작은 값을 부여해야한다. 사용자 입장에서 좋은 방식인가?
- 신규 프로세스 실행 비율에 대한 공정성이 지켜지는지?
- pass가 누적되면 overflow 될 가능성은 없나?
- 가장 작은 pass를 찾는 효율적인 방법

## 구현 계획

- 우선순위를 정하는 API인 setticket은 그대로 유지하자.
- tickets의 반비례되는 수인 stride를 만들기 위해 max_tickets(교재의 L)를 정한다.
  - stride = L / tickets
- 신규 프로세스에는 현재 실행중인 프로세스중에서 가장 작은 pass를 부여하여 공정성을 유지한다.
- pass를 uin64로 지정하고 max_tickets를 2^32로만 잡아도 최대 42.9억번 정도의 tick이 지나야 overflow가 발생한다. 지금은 고려하지 말자.
- 초기 구현은 선형탐색으로 단순하게 구현하고 이후 최적화를 하자.